### PR TITLE
Add Swagger API documentation with SpringDoc OpenAPI 3 integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,11 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
-
+        <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
+            <version>2.4.0</version>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,7 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
             <version>2.4.0</version>
         </dependency>
-        <dependency>
-            <groupId>org.springdoc</groupId>
-            <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
-            <version>2.4.0</version>
-        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
         </dependency>
         <dependency>
             <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
             <version>2.4.0</version>
         </dependency>

--- a/src/main/java/com/app/config/OpenAPIConfig.java
+++ b/src/main/java/com/app/config/OpenAPIConfig.java
@@ -1,0 +1,42 @@
+package com.app.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class OpenAPIConfig {
+
+    @Value("${app.openapi.endpoint}")
+    private String applicationEndpoint;
+
+    @Bean
+    public OpenAPI myOpenAPI() {
+        Server devServer = new Server();
+        devServer.setUrl(applicationEndpoint);
+        devServer.setDescription("Server Endpoint");
+
+        Contact contact = new Contact();
+        contact.setEmail("faiz.krm@gmail.com");
+        contact.setName("Faiz Akram");
+        contact.setUrl("https://www.faizkram.com");
+
+        License mitLicense = new License().name("Development License").url("https://www.faizkram.com");
+
+        Info info = new Info()
+                .title("Tutorial Management API")
+                .version("1.0")
+                .contact(contact)
+                .description("This API exposes endpoints to manage tutorials.").termsOfService("https://www.faizkram.com")
+                .license(mitLicense);
+
+        return new OpenAPI().info(info).servers(List.of(devServer));
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,8 @@
 spring:
-    application:
-        name: QuickStartSpringBoot
+  profiles:
+    active: local
+  application:
+    name: QuickStartSpringBoot
 server:
   port: 8080
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,6 +1,12 @@
 spring:
-    application:
-        name: QuickStartSpringBoot
+  application:
+    name: QuickStartSpringBoot
 server:
-    port: 8080
+  port: 8080
 
+springdoc:
+  swagger-ui:
+    path: /swagger-ui.html
+app:
+  openapi:
+    endpoint: http://localhost:8080


### PR DESCRIPTION
This pull request introduces API documentation for the application using Swagger with SpringDoc OpenAPI 3 integration. It leverages the `springdoc-openapi-starter-webmvc-api` dependency to automatically generate and expose API documentation for all REST endpoints.

### Key Features

1. **Swagger UI Integration:**
   - Adds Swagger UI to the application, providing a user-friendly interface to interact with and test all available REST APIs.
   - Automatically generates API documentation based on the existing controllers, request mappings, and model definitions.

2. **Real-time API Documentation:**
   - Documentation is dynamically generated and updated based on annotations and configurations within the codebase.
   - Supports standard OpenAPI 3 features like parameter descriptions, request/response schemas, and example values.

3. **Easy Access and Testing:**
   - The Swagger UI is accessible via the default endpoint: `/swagger-ui.html`.
   - Provides a convenient way for developers, testers, and external partners to understand and test the available APIs.

### How to Access Swagger UI

Once the application is running, you can access the Swagger UI for API documentation by navigating to:


### How to Test

To verify the Swagger integration:

1. Start the application.
2. Open a web browser and go to `http://localhost:8080/swagger-ui.html`.
3. Review the auto-generated documentation for all REST endpoints.
4. Use the Swagger UI to test various endpoints by sending requests directly from the interface.

### Added Dependency

To enable Swagger with SpringDoc OpenAPI 3, the following dependency has been added to `pom.xml`:

```xml
<dependency>
    <groupId>org.springdoc</groupId>
    <artifactId>springdoc-openapi-starter-webmvc-api</artifactId>
    <version>2.4.0</version>
</dependency>


