### PR TITLE
Add Dynamic CORS Configuration for Spring Boot Application

### DIFF
--- a/src/main/java/com/app/config/CorsConfiguration.java
+++ b/src/main/java/com/app/config/CorsConfiguration.java
@@ -1,0 +1,29 @@
+package com.app.config;
+
+import lombok.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class CorsConfiguration {
+    @Value("#{'${spring.web.allow.cors}'.split(',')}")
+    private String[] allowedEndPoint;
+
+    @Bean
+    public WebMvcConfigurer setCorsWebMvcConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(@NonNull CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins(allowedEndPoint)
+                        .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true)
+                        .maxAge(3600);
+            }
+        };
+    }
+}

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -2,3 +2,7 @@ app:
   logs:
     path: C:/${spring.application.name}/logs
 
+spring:
+  web:
+    allow:
+      cors: http://localhost:8080,http://localhost:4200


### PR DESCRIPTION
# Dynamic CORS Configuration for Spring Boot Application

This project implements a dynamic and configurable CORS (Cross-Origin Resource Sharing) policy in a Spring Boot application. The configuration allows flexibility to define `allowedOrigins` through externalized application properties and supports various HTTP methods, headers, and credentials.

---

## Features

1. **Dynamic CORS Endpoints**  
   - CORS origins are dynamically read from the `spring.web.allow.cors` property in the application's configuration files (e.g., `application.yml` or `application.properties`).

2. **Supported HTTP Methods**  
   - `GET`, `POST`, `PUT`, `PATCH`, `DELETE`, `OPTIONS`

3. **Credential Support**  
   - CORS configuration allows cross-origin credentials, such as cookies or authentication headers, to be shared between client and server.

4. **Custom Headers**  
   - Allows all headers (`*`) by default for flexibility, with the option to specify necessary headers explicitly.

5. **Environment-Specific Configurations**  
   - Different environments (e.g., development, production) can use separate configurations for better security and flexibility.

6. **Max Cache Age**  
   - Preflight requests are cached for 3600 seconds (1 hour).

---

## Configuration

### Application Properties

Define the allowed origins in `application.properties` or `application.yml`:

```properties
spring.web.allow.cors=http://localhost:3000,http://localhost:4200
