### PR TITLE
🚀 Add AOP-based Logging for Method Entry & Exit in Spring Boot Application

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,6 +29,10 @@
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-aop</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-log4j2</artifactId>
         </dependency>
         <dependency>

--- a/src/main/java/com/app/config/ApplicationLogging.java
+++ b/src/main/java/com/app/config/ApplicationLogging.java
@@ -1,0 +1,35 @@
+package com.app.config;
+
+import lombok.extern.log4j.Log4j2;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.AfterReturning;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+
+@Component
+@Aspect
+@Log4j2
+public class ApplicationLogging {
+
+    @Pointcut("within(com.app..*) && !within(com.app.config..*)")
+    public void applicationPackagePointcut() {
+        // Pointcut to capture all methods within the specified package
+    }
+
+    @Before("applicationPackagePointcut()")
+    public void logMethodEntry(JoinPoint joinPoint) {
+        String methodName = joinPoint.getSignature().getName();
+        String className = joinPoint.getTarget().getClass().getSimpleName();
+        Object[] args = joinPoint.getArgs();
+        log.info("Entering method: {}.{}() with arguments: {}", className, methodName, args);
+    }
+
+    @AfterReturning(pointcut = "applicationPackagePointcut()", returning = "result")
+    public void logMethodExit(JoinPoint joinPoint, Object result) {
+        String methodName = joinPoint.getSignature().getName();
+        String className = joinPoint.getTarget().getClass().getSimpleName();
+        log.info("Exiting method: {}.{}() with result: {}", className, methodName, result);
+    }
+}


### PR DESCRIPTION
## Overview
This PR introduces application-wide logging using **Spring AOP** to track method executions within the `com.app` package. The implementation ensures better visibility into method calls, arguments, and return values.

## Changes Introduced
- ✅ Added `@Aspect`-based logging in `ApplicationLogging` class.
- ✅ Implemented `@Pointcut` to capture method executions across the application while excluding configuration classes.
- ✅ Used `@Before` and `@AfterReturning` to log method entry and exit.
- ✅ Integrated **Lombok's** `@Log4j2` for structured logging.

## Why this is needed?
- Improves observability by providing logs for method calls and returned values.
- Helps with debugging and monitoring application behavior in real-time.

## How to Test?
1. Run the Spring Boot application.
2. Invoke any method in the `com.app` package.
3. Check the application logs for structured method execution details.